### PR TITLE
Geminiの使用方法をpackageからrestAPIで持ってくるように変更

### DIFF
--- a/3DMindMap.xcodeproj/project.pbxproj
+++ b/3DMindMap.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		72AC59F42D8FC19C00B3F30D /* .env in Resources */ = {isa = PBXBuildFile; fileRef = 72AC59F32D8FC19800B3F30D /* .env */; };
+		720E91F32DB7A6B20072F07F /* .env in Resources */ = {isa = PBXBuildFile; fileRef = 720E91F22DB7A6AD0072F07F /* .env */; };
+		720E91F62DB7AB4F0072F07F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 720E91F52DB7AB4F0072F07F /* Alamofire */; };
 		94CD8A7D2D8DB604009FA3AA /* RealityKitContent in Frameworks */ = {isa = PBXBuildFile; productRef = 94CD8A7C2D8DB604009FA3AA /* RealityKitContent */; };
-		9EF913112D8FAB8000610E46 /* GoogleGenerativeAI in Frameworks */ = {isa = PBXBuildFile; productRef = 9EF913102D8FAB8000610E46 /* GoogleGenerativeAI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		72AC59F32D8FC19800B3F30D /* .env */ = {isa = PBXFileReference; lastKnownFileType = text; path = .env; sourceTree = "<group>"; };
+		720E91F22DB7A6AD0072F07F /* .env */ = {isa = PBXFileReference; lastKnownFileType = text; path = .env; sourceTree = "<group>"; };
 		94CD8A772D8DB604009FA3AA /* 3DMindMap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = 3DMindMap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		94CD8A7B2D8DB604009FA3AA /* RealityKitContent */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = RealityKitContent; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -44,8 +44,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				720E91F62DB7AB4F0072F07F /* Alamofire in Frameworks */,
 				94CD8A7D2D8DB604009FA3AA /* RealityKitContent in Frameworks */,
-				9EF913112D8FAB8000610E46 /* GoogleGenerativeAI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,7 +55,7 @@
 		94CD8A6E2D8DB604009FA3AA = {
 			isa = PBXGroup;
 			children = (
-				72AC59F32D8FC19800B3F30D /* .env */,
+				720E91F22DB7A6AD0072F07F /* .env */,
 				94CD8A792D8DB604009FA3AA /* 3DMindMap */,
 				94CD8A7A2D8DB604009FA3AA /* Packages */,
 				94CD8A782D8DB604009FA3AA /* Products */,
@@ -99,7 +99,7 @@
 			name = 3DMindMap;
 			packageProductDependencies = (
 				94CD8A7C2D8DB604009FA3AA /* RealityKitContent */,
-				9EF913102D8FAB8000610E46 /* GoogleGenerativeAI */,
+				720E91F52DB7AB4F0072F07F /* Alamofire */,
 			);
 			productName = 3DMindMap;
 			productReference = 94CD8A772D8DB604009FA3AA /* 3DMindMap.app */;
@@ -130,7 +130,7 @@
 			mainGroup = 94CD8A6E2D8DB604009FA3AA;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				9EF9130F2D8FAB8000610E46 /* XCRemoteSwiftPackageReference "generative-ai-swift" */,
+				720E91F42DB7AB4F0072F07F /* XCRemoteSwiftPackageReference "Alamofire" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 94CD8A782D8DB604009FA3AA /* Products */;
@@ -147,7 +147,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				72AC59F42D8FC19C00B3F30D /* .env in Resources */,
+				720E91F32DB7A6B20072F07F /* .env in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -363,25 +363,25 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		9EF9130F2D8FAB8000610E46 /* XCRemoteSwiftPackageReference "generative-ai-swift" */ = {
+		720E91F42DB7AB4F0072F07F /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/google/generative-ai-swift";
+			repositoryURL = "https://github.com/Alamofire/Alamofire.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.6;
+				minimumVersion = 5.10.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		720E91F52DB7AB4F0072F07F /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 720E91F42DB7AB4F0072F07F /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
 		94CD8A7C2D8DB604009FA3AA /* RealityKitContent */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = RealityKitContent;
-		};
-		9EF913102D8FAB8000610E46 /* GoogleGenerativeAI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 9EF9130F2D8FAB8000610E46 /* XCRemoteSwiftPackageReference "generative-ai-swift" */;
-			productName = GoogleGenerativeAI;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/3DMindMap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/3DMindMap.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0df664f125fa11c47946ec126b2052cf5b01925b34bd8b5af496e9da7c013d09",
+  "originHash" : "9420ca262ee7d90a22de564faaa6cbea771e34f9d0d4782e8b23bdddf2cfee27",
   "pins" : [
     {
-      "identity" : "generative-ai-swift",
+      "identity" : "alamofire",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/generative-ai-swift",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "44b8ce120425f9cf53ca756f3434ca2c2696f8bd",
-        "version" : "0.5.6"
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
       }
     }
   ],

--- a/3DMindMap/Models/Repository/GetIdeasRepository.swift
+++ b/3DMindMap/Models/Repository/GetIdeasRepository.swift
@@ -1,49 +1,124 @@
-import GoogleGenerativeAI
+
 import Foundation
+import Alamofire
 
-let env = try? LoadEnv()
+let env = try! LoadEnv()
 
-let model = GenerativeModel(name: "gemini-1.5-flash", apiKey: "AIzaSyB8PMdY-uHFRWZD79lOxjWIuateNsAFIME")
+//let model = GenerativeModel(name: "gemini-1.5-flash", apiKey: "AIzaSyB8PMdY-uHFRWZD79lOxjWIuateNsAFIME")
 
 struct GetIdeasRepository {
     let content: String
-    
-    func get() async -> [String]? {
-            let prompt = """
-            Three minor words of minor types related to a given word are provided in JSON format, similar to an array of strings: \(content)
-            """
-            
-            do {
-                // 1. モデルからレスポンスを取得
-                let response = try await model.generateContent(prompt)
-                
-                // 2. レスポンスのテキスト部分があるか確認
-                if let text = response.text {
-                    // 3. 余分な部分を削除
-                    let cleanedString = text
-                        .replacingOccurrences(of: "```json\n", with: "")
-                        .replacingOccurrences(of: "\n```", with: "")
-                    
-                    // 4. JSON デコード
-                    if let jsonData = cleanedString.data(using: .utf8) {
-                        do {
-                            let decodedArray = try JSONDecoder().decode([String].self, from: jsonData)
-                            print(decodedArray)
-                            return decodedArray
-                        } catch {
-                            print("JSON decoding failed: \(error.localizedDescription)")
-                        }
-                    } else {
-                        print("Failed to convert string to data.")
-                    }
-                } else {
-                    print("Response did not contain any text.")
+    func getGeminiIdeas() async -> [String] {
+        let prompt = """
+           「\(content)」に関連するマイナーな日本語単語を3つ、以下の形式でJSONで返してください（前後に説明は不要です）:
+
+           ["〇〇", "〇〇", "〇〇"]
+        """
+
+        let url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+        let params: Parameters = [
+            "contents":[
+                [
+                    "parts": [
+                        ["text": prompt]
+                    ]
+                ]
+            ]
+        ]
+        let headers: HTTPHeaders = [
+            "Content-Type":"application/json",
+        ]
+
+        do {
+            let data = try await AF.request("\(url)?key=\(env.value("APIKEY") ?? "")",
+                                            method: .post,
+                                            parameters: params,
+                                            encoding: JSONEncoding.default,
+                                            headers: headers)
+                .serializingDecodable(GeminiResponse.self).value
+
+            if let text = data.candidates.first?.content.parts.first?.text {
+                let cleaned = text
+                    .replacingOccurrences(of: "```json\n", with: "")
+                    .replacingOccurrences(of: "\n```", with: "")
+
+                if let jsonData = cleaned.data(using: .utf8) {
+                    let result = try JSONDecoder().decode([String].self, from: jsonData)
+                    return result
                 }
-            } catch {
-                print("Error generating content: \(error.localizedDescription)")
             }
-            
-            // 5. 失敗時に nil を返す
-            return nil
+
+        } catch {
+            print("🚨 エラー:", error)
         }
+
+        return []
+    }
+
+    struct GeminiResponse: Codable {
+        let candidates: [Candidate]
+        let usageMetadata: UsageMetadata
+        let modelVersion: String
+    }
+
+    struct Candidate: Codable {
+        let content: Content
+        let finishReason: String
+        let avgLogprobs: Double
+    }
+
+    struct Content: Codable {
+        let parts: [Part]
+        let role: String
+    }
+
+    struct Part: Codable {
+        let text: String
+    }
+
+    struct UsageMetadata: Codable {
+        let promptTokenCount: Int
+        let candidatesTokenCount: Int
+        let totalTokenCount: Int
+    }
+
+    //    func get() async -> [String]? {
+    //        let prompt = """
+    //            Three minor words of minor types related to a given word are provided in JSON format, similar to an array of strings: \(content)
+    //            """
+    //
+    //        do {
+    //            // 1. モデルからレスポンスを取得
+    //            let response = try await model.generateContent(prompt)
+    //
+    //            // 2. レスポンスのテキスト部分があるか確認
+    //            if let text = response.text {
+    //                // 3. 余分な部分を削除
+    //                let cleanedString = text
+    //                    .replacingOccurrences(of: "```json\n", with: "")
+    //                    .replacingOccurrences(of: "\n```", with: "")
+    //
+    //                // 4. JSON デコード
+    //                if let jsonData = cleanedString.data(using: .utf8) {
+    //                    do {
+    //                        let decodedArray = try JSONDecoder().decode([String].self, from: jsonData)
+    //                        print(decodedArray)
+    //                        return decodedArray
+    //                    } catch {
+    //                        print("JSON decoding failed: \(error.localizedDescription)")
+    //                    }
+    //                } else {
+    //                    print("Failed to convert string to data.")
+    //                }
+    //            } else {
+    //                print("Response did not contain any text.")
+    //            }
+    //        } catch {
+    //            print("Error generating content: \(error.localizedDescription)")
+    //        }
+    //
+    //        // 5. 失敗時に nil を返す
+    //        return nil
+    //    }
+    //}
 }

--- a/3DMindMap/Models/Repository/GetIdeasRepository.swift
+++ b/3DMindMap/Models/Repository/GetIdeasRepository.swift
@@ -4,8 +4,6 @@ import Alamofire
 
 let env = try! LoadEnv()
 
-//let model = GenerativeModel(name: "gemini-1.5-flash", apiKey: "AIzaSyB8PMdY-uHFRWZD79lOxjWIuateNsAFIME")
-
 struct GetIdeasRepository {
     let content: String
     func getGeminiIdeas() async -> [String] {
@@ -82,43 +80,4 @@ struct GetIdeasRepository {
         let totalTokenCount: Int
     }
 
-    //    func get() async -> [String]? {
-    //        let prompt = """
-    //            Three minor words of minor types related to a given word are provided in JSON format, similar to an array of strings: \(content)
-    //            """
-    //
-    //        do {
-    //            // 1. モデルからレスポンスを取得
-    //            let response = try await model.generateContent(prompt)
-    //
-    //            // 2. レスポンスのテキスト部分があるか確認
-    //            if let text = response.text {
-    //                // 3. 余分な部分を削除
-    //                let cleanedString = text
-    //                    .replacingOccurrences(of: "```json\n", with: "")
-    //                    .replacingOccurrences(of: "\n```", with: "")
-    //
-    //                // 4. JSON デコード
-    //                if let jsonData = cleanedString.data(using: .utf8) {
-    //                    do {
-    //                        let decodedArray = try JSONDecoder().decode([String].self, from: jsonData)
-    //                        print(decodedArray)
-    //                        return decodedArray
-    //                    } catch {
-    //                        print("JSON decoding failed: \(error.localizedDescription)")
-    //                    }
-    //                } else {
-    //                    print("Failed to convert string to data.")
-    //                }
-    //            } else {
-    //                print("Response did not contain any text.")
-    //            }
-    //        } catch {
-    //            print("Error generating content: \(error.localizedDescription)")
-    //        }
-    //
-    //        // 5. 失敗時に nil を返す
-    //        return nil
-    //    }
-    //}
 }

--- a/3DMindMap/Utils/Manager/ImmersiveViewModel.swift
+++ b/3DMindMap/Utils/Manager/ImmersiveViewModel.swift
@@ -161,9 +161,7 @@ final class ImmersiveViewModel {
     
     func getIdeas(text: String) async -> [String] {
         let repository = GetIdeasRepository(content: text)
-        let ideas = await repository.get() ?? []
-        print(ideas)
+        let ideas = await repository.getGeminiIdeas()
         return ideas
     }
-
 }

--- a/3DMindMap/Utils/Manager/LoadEnv.swift
+++ b/3DMindMap/Utils/Manager/LoadEnv.swift
@@ -1,3 +1,4 @@
+
 import Foundation
 
 enum LoadEnvError: Error {
@@ -5,7 +6,7 @@ enum LoadEnvError: Error {
 }
 
 struct LoadEnv {
-    init(fileAt path: String = "(FileManager.default.currentDirectoryPath)/.env") throws {
+    init(fileAt path: String = "\(FileManager.default.currentDirectoryPath)/.env") throws {
         guard let envPath = Bundle.main.path(forResource: ".env", ofType: nil),
               let envData = FileManager.default.contents(atPath: envPath),
               let envString = String(data: envData, encoding: .utf8) else {
@@ -22,7 +23,7 @@ struct LoadEnv {
             }
     }
 
-    func value( key: String,  default: String? = nil) -> String? {
+    func value(_ key: String, _ default: String? = nil) -> String? {
         guard let value = getenv(key) else { return nil }
         return String(validatingUTF8: value)
     }


### PR DESCRIPTION
使用していたパッケージが4/15で非推奨になっていたので、RESTAPIとAlamofireを使ってデータを持ってくるように変更しました。


.envファイルは各々 **XCodeから！！！！！！** 作成してください
APIKEY=YOURAPIKEY
の形です。""はいらないです
